### PR TITLE
fix canvas rotation adding an undo item

### DIFF
--- a/rotate_canvas.py
+++ b/rotate_canvas.py
@@ -68,7 +68,7 @@ def draw_callback_px(self, context):
 class RC_OT_RotateCanvas(bpy.types.Operator):
     bl_idname = 'view3d.rotate_canvas'
     bl_label = 'Rotate Canvas'
-    bl_options = {"REGISTER", "UNDO"}
+    bl_options = {"REGISTER"}
 
     def get_center_view(self, context, cam):
         '''
@@ -308,7 +308,7 @@ class RC_OT_Reset_rotation(bpy.types.Operator):
     bl_idname = 'view3d.rotate_canvas_reset'
     bl_label = 'Restore Rotation'
     bl_description = 'Restore active camera rotation from previously saved state'
-    bl_options = {"REGISTER", "UNDO"}
+    bl_options = {"REGISTER"}
 
     @classmethod
     def poll(cls, context):


### PR DESCRIPTION
the canvas rotation/reset operations would create an undo item, which is nonsense. it bit me in the ass a few times, when undoing some changes (to compare the earlier state of the sculpt), moving around the model, only to realize it pruned my undo stack and destroyed my work.