### PR TITLE
Add Cmd/OS key modifier support for Rotate Canvas shortcut

### DIFF
--- a/prefs.py
+++ b/prefs.py
@@ -133,6 +133,12 @@ class GreasePencilAddonPrefs(bpy.types.AddonPreferences):
             default = True,
             update=auto_rebind)
 
+    use_oskey: BoolProperty(
+            name = "combine with Cmd/OS key",
+            description = "add Cmd key (macOS) or OS/Win key (Windows/Linux)",
+            default = False,
+            update=auto_rebind)
+
     rc_angle_step: FloatProperty(
         name="Angle Steps",
         description="Step the rotation using this angle when using rotate canvas step modifier",
@@ -189,12 +195,16 @@ class GreasePencilAddonPrefs(bpy.types.AddonPreferences):
                     row.prop(self, "use_ctrl", text='Ctrl')#, expand=True
                     row.prop(self, "use_alt", text='Alt')#, expand=True
                     row.prop(self, "use_shift", text='Shift')#, expand=True
+                    # Show "Cmd" on macOS, "OS" on other platforms
+                    import sys
+                    oskey_label = 'Cmd' if sys.platform == 'darwin' else 'OS'
+                    row.prop(self, "use_oskey", text=oskey_label)
                     row.prop(self, "mouse_click",text='')#expand=True
 
-                    if not self.use_ctrl and not self.use_alt and not self.use_shift:
+                    if not self.use_ctrl and not self.use_alt and not self.use_shift and not self.use_oskey:
                         box.label(text="Choose at least one modifier to combine with click (default: Ctrl+Alt)", icon="ERROR")# INFO
 
-                    if not all((self.use_ctrl, self.use_alt, self.use_shift)):
+                    if not all((self.use_ctrl, self.use_alt, self.use_shift, self.use_oskey)):
                         row = box.row(align = True)
                         snap_key_list = []
                         if not self.use_ctrl:
@@ -203,6 +213,8 @@ class GreasePencilAddonPrefs(bpy.types.AddonPreferences):
                             snap_key_list.append('Shift')
                         if not self.use_alt:
                             snap_key_list.append('Alt')
+                        if not self.use_oskey:
+                            snap_key_list.append(oskey_label)
 
                         row.label(text=f"Step rotation with: {' or '.join(snap_key_list)}", icon='DRIVER_ROTATIONAL_DIFFERENCE')
                         row.prop(self, "rc_angle_step", text='Angle Steps')
@@ -278,7 +290,7 @@ def register_keymaps():
     if 'view3d.rotate_canvas' not in km.keymap_items:
         km = kc.keymaps.new(name='3D View', space_type='VIEW_3D')
         kmi = km.keymap_items.new('view3d.rotate_canvas',
-        type=pref.mouse_click, value="PRESS", alt=pref.use_alt, ctrl=pref.use_ctrl, shift=pref.use_shift, any=False)
+        type=pref.mouse_click, value="PRESS", alt=pref.use_alt, ctrl=pref.use_ctrl, shift=pref.use_shift, oskey=pref.use_oskey, any=False)
 
         addon_keymaps.append((km, kmi))
 


### PR DESCRIPTION
**Summary**

This PR adds support for the Cmd key (macOS) / OS key (Windows/Linux) as a modifier option for the Rotate Canvas shortcut.

Currently, only Ctrl, Alt, and Shift are available as modifier options in the addon preferences. This is limiting for macOS users who commonly use Cmd-based shortcuts (e.g., Alt+Cmd+Click) and must manually add keymaps via Python to use Cmd as a modifier.

In older Blender versions, Ctrl often acted as Cmd on macOS, so macOS users could use the existing "Ctrl" option and it would work with their Cmd key. In Blender 4.3+, Ctrl and Cmd are now treated as separate keys. Since the addon only exposes Ctrl, Alt, and Shift as modifier options, macOS users can no longer use Cmd-based shortcuts without manually adding keymaps via Python.

**Compatibility**

Blender 4.3+ (tested on Blender 5.0.1)

**Changes**

- Added `use_oskey` BoolProperty with `auto_rebind` callback
- Updated `register_keymaps()` to pass the `oskey` parameter
- UI dynamically shows "Cmd" on macOS or "OS" on other platforms
- Updated modifier validation and step rotation modifier list to include oskey

**Test Plan**

- Tested on macOS with Blender 5.0.1
- Verified Cmd checkbox appears in Rotate Canvas preferences
- Verified Alt+Cmd+Left Mouse successfully triggers canvas rotation
- Verified "Bind Shortcuts" toggle correctly registers/unregisters the keymap

**Screenshots**

The preferences panel now shows a "Cmd" button (on macOS) alongside Ctrl, Alt, and Shift:

<img width="671" height="524" alt="Screenshot 2026-01-11 at 7 43 44 PM" src="https://github.com/user-attachments/assets/90dd5984-a64d-4445-92bc-51ff3682c58d" />
